### PR TITLE
alpine instead of ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM ubuntu:18.04
+FROM alpine:3.9
 
-ARG AKSENGINE_VERSION=0.33.3
+ARG AKSENGINE_VERSION=0.35.0
 
-RUN apt-get update \
- && apt-get install -y wget unzip \
- && rm -rf /var/lib/apt/lists/*
+# The Docker image is missing TLS root certificates, and as a result the aks-engine commands fail on TLS when connecting to Azure services via HTTPS.
+RUN apk add --no-cache -u ca-certificates
 
-RUN wget https://github.com/Azure/aks-engine/releases/download/v${AKSENGINE_VERSION}/aks-engine-v${AKSENGINE_VERSION}-linux-amd64.zip \
- &&	unzip aks-engine-v${AKSENGINE_VERSION}-linux-amd64.zip \
+ADD "https://github.com/Azure/aks-engine/releases/download/v${AKSENGINE_VERSION}/aks-engine-v${AKSENGINE_VERSION}-linux-amd64.tar.gz" /tmp/aks-engine.tgz
+
+RUN tar xvzf /tmp/aks-engine.tgz \
+ && rm /tmp/aks-engine.tgz
  && mv aks-engine-v${AKSENGINE_VERSION}-linux-amd64/aks-engine /usr/local/bin/aks-engine \
- && rm aks-engine-v${AKSENGINE_VERSION}-linux-amd64.zip \
  && rm -r aks-engine-v${AKSENGINE_VERSION}-linux-amd64
+
+ENTRYPOINT ["aks-engine"]
+CMD ["--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache -u ca-certificates
 ADD "https://github.com/Azure/aks-engine/releases/download/v${AKSENGINE_VERSION}/aks-engine-v${AKSENGINE_VERSION}-linux-amd64.tar.gz" /tmp/aks-engine.tgz
 
 RUN tar xvzf /tmp/aks-engine.tgz \
- && rm /tmp/aks-engine.tgz
+ && rm /tmp/aks-engine.tgz \
  && mv aks-engine-v${AKSENGINE_VERSION}-linux-amd64/aks-engine /usr/local/bin/aks-engine \
  && rm -r aks-engine-v${AKSENGINE_VERSION}-linux-amd64
 


### PR DESCRIPTION
This PR is simplifying and decreasing the size of the image build, from `ubuntu`, we are now with `alpine`. This implementation took inspiration from there: https://github.com/Azure/aks-engine/blob/master/releases/Dockerfile.linux